### PR TITLE
use secrets manager instead of parameter store as string raises cfn-scanner failure AND securestring is not supported for reference for Amplify;

### DIFF
--- a/eco-wise/back-end/templates/root-stack.yaml
+++ b/eco-wise/back-end/templates/root-stack.yaml
@@ -8,7 +8,7 @@ Resources:
     Type: "AWS::Amplify::App"
     DeletionPolicy: "Retain"
     Properties:
-      AccessToken: '{{resolve:ssm:GithubAccessToken}}'
+      AccessToken: "{{resolve:secretsmanager:GithubAccessToken:SecretString:GithubAccessToken}}"
       Repository: "https://github.com/EcoWiseTech/EcoWise"
       Platform: "WEB"
       EnableBranchAutoDeletion: false


### PR DESCRIPTION
use secrets manager instead of parameter store as string raises cfn-scanner failure AND securestring is not supported for reference for Amplify;